### PR TITLE
fixup(readme): Align references to git repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ Python 3.9+
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
+pip install git+https://github.com/goauthentik/client-python.git
 ```
-(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
 
 Then import the package:
 ```python
@@ -46,7 +45,6 @@ Install via [Setuptools](http://pypi.python.org/pypi/setuptools).
 ```sh
 python setup.py install --user
 ```
-(or `sudo python setup.py install` to install the package for all users)
 
 Then import the package:
 ```python


### PR DESCRIPTION
Change `GIT_USER_ID/GIT_REPO_ID.git` for the proper GitHub repo URL.

Additionally, removed references to root permissions for `pip install` commands.